### PR TITLE
Implement keystore files with mnemonic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "3.0.0-alpha.3",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-wallet",
-      "version": "3.0.0-alpha.3",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.20.14",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.14.tgz",
-      "integrity": "sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==",
+      "version": "7.20.10",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
+      "integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.20.14",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
-      "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
+      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7",
@@ -278,13 +278,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
-      "integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
+      "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.13",
+        "@babel/traverse": "^7.20.7",
         "@babel/types": "^7.20.7"
       },
       "engines": {
@@ -306,9 +306,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
-      "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
+      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -385,9 +385,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
-      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.12.tgz",
+      "integrity": "sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
@@ -396,7 +396,7 @@
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.13",
+        "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -1195,9 +1195,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.21.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "funding": [
         {
@@ -1210,10 +1210,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.9"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1305,9 +1305,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001449",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz",
-      "integrity": "sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==",
+      "version": "1.0.30001444",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001444.tgz",
+      "integrity": "sha512-ecER9xgJQVMqcrxThKptsW0pPxSae8R2RB87LNa+ivW9ppNWRHEplXcDzkCOP4LYWGj8hunXLqaiC41iBATNyg==",
       "dev": true,
       "funding": [
         {
@@ -1939,6 +1939,20 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -1979,9 +1993,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -4169,9 +4183,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.20.14",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.14.tgz",
-      "integrity": "sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==",
+      "version": "7.20.10",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
+      "integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
       "dev": true
     },
     "@babel/core": {
@@ -4198,9 +4212,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.20.14",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
-      "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
+      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.20.7",
@@ -4327,13 +4341,13 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
-      "integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
+      "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.13",
+        "@babel/traverse": "^7.20.7",
         "@babel/types": "^7.20.7"
       }
     },
@@ -4349,9 +4363,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
-      "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
+      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -4404,9 +4418,9 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
-      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.12.tgz",
+      "integrity": "sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
@@ -4415,7 +4429,7 @@
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.13",
+        "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -5121,15 +5135,15 @@
       }
     },
     "browserslist": {
-      "version": "4.21.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.9"
       }
     },
     "buffer": {
@@ -5189,9 +5203,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001449",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz",
-      "integrity": "sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==",
+      "version": "1.0.30001444",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001444.tgz",
+      "integrity": "sha512-ecER9xgJQVMqcrxThKptsW0pPxSae8R2RB87LNa+ivW9ppNWRHEplXcDzkCOP4LYWGj8hunXLqaiC41iBATNyg==",
       "dev": true
     },
     "chai": {
@@ -5706,6 +5720,13 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5737,9 +5758,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "2.1.3",
+  "version": "v3.0.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-wallet",
-      "version": "2.1.3",
+      "version": "v3.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.20.10",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
-      "integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.14.tgz",
+      "integrity": "sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
-      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
+      "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7",
@@ -278,13 +278,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
-      "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
+      "integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.7",
+        "@babel/traverse": "^7.20.13",
         "@babel/types": "^7.20.7"
       },
       "engines": {
@@ -306,9 +306,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
-      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
+      "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -385,9 +385,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.20.12",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.12.tgz",
-      "integrity": "sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
+      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
@@ -396,7 +396,7 @@
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.7",
+        "@babel/parser": "^7.20.13",
         "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -1305,9 +1305,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001444",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001444.tgz",
-      "integrity": "sha512-ecER9xgJQVMqcrxThKptsW0pPxSae8R2RB87LNa+ivW9ppNWRHEplXcDzkCOP4LYWGj8hunXLqaiC41iBATNyg==",
+      "version": "1.0.30001449",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz",
+      "integrity": "sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==",
       "dev": true,
       "funding": [
         {
@@ -1993,9 +1993,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -4183,9 +4183,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.20.10",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
-      "integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.14.tgz",
+      "integrity": "sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==",
       "dev": true
     },
     "@babel/core": {
@@ -4212,9 +4212,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
-      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
+      "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.20.7",
@@ -4341,13 +4341,13 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
-      "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
+      "integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.7",
+        "@babel/traverse": "^7.20.13",
         "@babel/types": "^7.20.7"
       }
     },
@@ -4363,9 +4363,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
-      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
+      "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -4418,9 +4418,9 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.20.12",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.12.tgz",
-      "integrity": "sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
+      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
@@ -4429,7 +4429,7 @@
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.7",
+        "@babel/parser": "^7.20.13",
         "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -5203,9 +5203,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001444",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001444.tgz",
-      "integrity": "sha512-ecER9xgJQVMqcrxThKptsW0pPxSae8R2RB87LNa+ivW9ppNWRHEplXcDzkCOP4LYWGj8hunXLqaiC41iBATNyg==",
+      "version": "1.0.30001449",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz",
+      "integrity": "sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==",
       "dev": true
     },
     "chai": {
@@ -5758,9 +5758,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "v3.0.0-alpha.2",
+  "version": "3.0.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-wallet",
-      "version": "v3.0.0-alpha.2",
+      "version": "3.0.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",
@@ -1195,9 +1195,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "dev": true,
       "funding": [
         {
@@ -1210,10 +1210,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1938,20 +1938,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -5135,15 +5121,15 @@
       }
     },
     "browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       }
     },
     "buffer": {
@@ -5719,13 +5705,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "v3.0.0-alpha.2",
+  "version": "3.0.0-alpha.3",
   "description": "Wallet components for MultiversX",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "3.0.0-alpha.3",
+  "version": "3.0.0",
   "description": "Wallet components for MultiversX",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "2.1.3",
+  "version": "v3.0.0-alpha.2",
   "description": "Wallet components for MultiversX",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/crypto/constants.ts
+++ b/src/crypto/constants.ts
@@ -1,5 +1,3 @@
-// In a future PR, improve versioning infrastructure for key-file objects.
-export const Version = 4;
 export const CipherAlgorithm = "aes-128-ctr";
 export const DigestAlgorithm = "sha256";
 export const KeyDerivationFunction = "scrypt";

--- a/src/crypto/encrypt.spec.ts
+++ b/src/crypto/encrypt.spec.ts
@@ -6,7 +6,7 @@ import { Encryptor } from "./encryptor";
 describe("test address", () => {
   it("encrypts/decrypts", () => {
     const sensitiveData = Buffer.from("my mnemonic");
-    const encryptedData = Encryptor.encrypt(4, sensitiveData, "password123");
+    const encryptedData = Encryptor.encrypt(sensitiveData, "password123");
     const decryptedBuffer = Decryptor.decrypt(encryptedData, "password123");
 
     assert.equal(sensitiveData.toString('hex'), decryptedBuffer.toString('hex'));
@@ -14,13 +14,9 @@ describe("test address", () => {
 
   it("encodes/decodes kdfparams", () => {
     const sensitiveData = Buffer.from("my mnemonic");
-    const encryptedData = Encryptor.encrypt(4, sensitiveData, "password123");
+    const encryptedData = Encryptor.encrypt(sensitiveData, "password123");
     const decodedData = EncryptedData.fromJSON(encryptedData.toJSON());
 
     assert.deepEqual(decodedData, encryptedData, "invalid decoded data");
-  });
-
-  it("fails for bad version", () => {
-    assert.throws(() => Encryptor.encrypt(5, Buffer.from(""), ""), "Encryptor: unsupported version 5");
   });
 });

--- a/src/crypto/encrypt.spec.ts
+++ b/src/crypto/encrypt.spec.ts
@@ -1,12 +1,12 @@
 import { assert } from "chai";
-import { Encryptor } from "./encryptor";
 import { Decryptor } from "./decryptor";
 import { EncryptedData } from "./encryptedData";
+import { Encryptor } from "./encryptor";
 
 describe("test address", () => {
-  it("encrypts/decrypts",  () => {
+  it("encrypts/decrypts", () => {
     const sensitiveData = Buffer.from("my mnemonic");
-    const encryptedData = Encryptor.encrypt(sensitiveData, "password123");
+    const encryptedData = Encryptor.encrypt(7, sensitiveData, "password123");
     const decryptedBuffer = Decryptor.decrypt(encryptedData, "password123");
 
     assert.equal(sensitiveData.toString('hex'), decryptedBuffer.toString('hex'));
@@ -14,7 +14,7 @@ describe("test address", () => {
 
   it("encodes/decodes kdfparams", () => {
     const sensitiveData = Buffer.from("my mnemonic");
-    const encryptedData = Encryptor.encrypt(sensitiveData, "password123");
+    const encryptedData = Encryptor.encrypt(7, sensitiveData, "password123");
     const decodedData = EncryptedData.fromJSON(encryptedData.toJSON());
 
     assert.deepEqual(decodedData, encryptedData, "invalid decoded data");

--- a/src/crypto/encrypt.spec.ts
+++ b/src/crypto/encrypt.spec.ts
@@ -6,7 +6,7 @@ import { Encryptor } from "./encryptor";
 describe("test address", () => {
   it("encrypts/decrypts", () => {
     const sensitiveData = Buffer.from("my mnemonic");
-    const encryptedData = Encryptor.encrypt(7, sensitiveData, "password123");
+    const encryptedData = Encryptor.encrypt(4, sensitiveData, "password123");
     const decryptedBuffer = Decryptor.decrypt(encryptedData, "password123");
 
     assert.equal(sensitiveData.toString('hex'), decryptedBuffer.toString('hex'));
@@ -14,9 +14,13 @@ describe("test address", () => {
 
   it("encodes/decodes kdfparams", () => {
     const sensitiveData = Buffer.from("my mnemonic");
-    const encryptedData = Encryptor.encrypt(7, sensitiveData, "password123");
+    const encryptedData = Encryptor.encrypt(4, sensitiveData, "password123");
     const decodedData = EncryptedData.fromJSON(encryptedData.toJSON());
 
     assert.deepEqual(decodedData, encryptedData, "invalid decoded data");
+  });
+
+  it("fails for bad version", () => {
+    assert.throws(() => Encryptor.encrypt(5, Buffer.from(""), ""), "Encryptor: unsupported version 5");
   });
 });

--- a/src/crypto/encryptor.ts
+++ b/src/crypto/encryptor.ts
@@ -1,11 +1,15 @@
 import crypto from "crypto";
-import { Randomness } from "./randomness";
+import { CipherAlgorithm, DigestAlgorithm, KeyDerivationFunction } from "./constants";
 import { ScryptKeyDerivationParams } from "./derivationParams";
-import { CipherAlgorithm, DigestAlgorithm, Version, KeyDerivationFunction } from "./constants";
-import {EncryptedData} from "./encryptedData";
+import { EncryptedData } from "./encryptedData";
+import { Randomness } from "./randomness";
+
+export enum EncryptorVersion {
+  V4 = 4,
+}
 
 export class Encryptor {
-  static encrypt(data: Buffer, password: string, randomness: Randomness = new Randomness()): EncryptedData {
+  static encrypt(version: EncryptorVersion, data: Buffer, password: string, randomness: Randomness = new Randomness()): EncryptedData {
     const kdParams = new ScryptKeyDerivationParams();
     const derivedKey = kdParams.generateDerivedKey(Buffer.from(password), randomness.salt);
     const derivedKeyFirstHalf = derivedKey.slice(0, 16);
@@ -16,7 +20,7 @@ export class Encryptor {
     const mac = crypto.createHmac(DigestAlgorithm, derivedKeySecondHalf).update(ciphertext).digest();
 
     return new EncryptedData({
-      version: Version,
+      version: version,
       id: randomness.id,
       ciphertext: ciphertext.toString('hex'),
       iv: randomness.iv.toString('hex'),

--- a/src/crypto/encryptor.ts
+++ b/src/crypto/encryptor.ts
@@ -4,12 +4,18 @@ import { ScryptKeyDerivationParams } from "./derivationParams";
 import { EncryptedData } from "./encryptedData";
 import { Randomness } from "./randomness";
 
+interface IRandomness {
+  id: string;
+  iv: Buffer;
+  salt: Buffer;
+}
+
 export enum EncryptorVersion {
   V4 = 4,
 }
 
 export class Encryptor {
-  static encrypt(data: Buffer, password: string, randomness: Randomness = new Randomness()): EncryptedData {
+  static encrypt(data: Buffer, password: string, randomness: IRandomness = new Randomness()): EncryptedData {
     const kdParams = new ScryptKeyDerivationParams();
     const derivedKey = kdParams.generateDerivedKey(Buffer.from(password), randomness.salt);
     const derivedKeyFirstHalf = derivedKey.slice(0, 16);

--- a/src/crypto/encryptor.ts
+++ b/src/crypto/encryptor.ts
@@ -1,4 +1,5 @@
 import crypto from "crypto";
+import { Err } from "../errors";
 import { CipherAlgorithm, DigestAlgorithm, KeyDerivationFunction } from "./constants";
 import { ScryptKeyDerivationParams } from "./derivationParams";
 import { EncryptedData } from "./encryptedData";
@@ -10,6 +11,10 @@ export enum EncryptorVersion {
 
 export class Encryptor {
   static encrypt(version: EncryptorVersion, data: Buffer, password: string, randomness: Randomness = new Randomness()): EncryptedData {
+    if (version != EncryptorVersion.V4) {
+      throw new Err(`Encryptor: unsupported version ${version}`);
+    }
+
     const kdParams = new ScryptKeyDerivationParams();
     const derivedKey = kdParams.generateDerivedKey(Buffer.from(password), randomness.salt);
     const derivedKeyFirstHalf = derivedKey.slice(0, 16);

--- a/src/crypto/encryptor.ts
+++ b/src/crypto/encryptor.ts
@@ -1,5 +1,4 @@
 import crypto from "crypto";
-import { Err } from "../errors";
 import { CipherAlgorithm, DigestAlgorithm, KeyDerivationFunction } from "./constants";
 import { ScryptKeyDerivationParams } from "./derivationParams";
 import { EncryptedData } from "./encryptedData";
@@ -10,11 +9,7 @@ export enum EncryptorVersion {
 }
 
 export class Encryptor {
-  static encrypt(version: EncryptorVersion, data: Buffer, password: string, randomness: Randomness = new Randomness()): EncryptedData {
-    if (version != EncryptorVersion.V4) {
-      throw new Err(`Encryptor: unsupported version ${version}`);
-    }
-
+  static encrypt(data: Buffer, password: string, randomness: Randomness = new Randomness()): EncryptedData {
     const kdParams = new ScryptKeyDerivationParams();
     const derivedKey = kdParams.generateDerivedKey(Buffer.from(password), randomness.salt);
     const derivedKeyFirstHalf = derivedKey.slice(0, 16);
@@ -25,7 +20,7 @@ export class Encryptor {
     const mac = crypto.createHmac(DigestAlgorithm, derivedKeySecondHalf).update(ciphertext).digest();
 
     return new EncryptedData({
-      version: version,
+      version: EncryptorVersion.V4,
       id: randomness.id,
       ciphertext: ciphertext.toString('hex'),
       iv: randomness.iv.toString('hex'),

--- a/src/mnemonic.ts
+++ b/src/mnemonic.ts
@@ -1,7 +1,7 @@
-import { generateMnemonic, validateMnemonic, mnemonicToSeedSync } from "bip39";
-import { UserSecretKey } from "./userKeys";
+import { generateMnemonic, mnemonicToSeedSync, validateMnemonic } from "bip39";
 import { derivePath } from "ed25519-hd-key";
 import { ErrWrongMnemonic } from "./errors";
+import { UserSecretKey } from "./userKeys";
 
 const MNEMONIC_STRENGTH = 256;
 const BIP44_DERIVATION_PREFIX = "m/44'/508'/0'/0'";
@@ -20,12 +20,12 @@ export class Mnemonic {
 
     static fromString(text: string) {
         text = text.trim();
-        
+
         Mnemonic.assertTextIsValid(text);
         return new Mnemonic(text);
     }
 
-    private static assertTextIsValid(text: string) {
+    public static assertTextIsValid(text: string) {
         let isValid = validateMnemonic(text);
 
         if (!isValid) {

--- a/src/testdata/bob.json
+++ b/src/testdata/bob.json
@@ -1,5 +1,6 @@
 {
     "version": 4,
+    "kind": "secretKey",
     "id": "85fdc8a7-7119-479d-b7fb-ab4413ed038d",
     "address": "8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8",
     "bech32": "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",

--- a/src/testdata/carol.json
+++ b/src/testdata/carol.json
@@ -1,5 +1,6 @@
 {
     "version": 4,
+    "kind": "secretKey",
     "id": "65894f35-d142-41d2-9335-6ad02e0ed0be",
     "address": "b2a11555ce521e4944e09ab17549d85b487dcd26c84b5017a39e31a3670889ba",
     "bech32": "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8",

--- a/src/testdata/withDummyMnemonic.json
+++ b/src/testdata/withDummyMnemonic.json
@@ -1,0 +1,21 @@
+{
+    "version": 4,
+    "id": "5b448dbc-5c72-4d83-8038-938b1f8dff19",
+    "kind": "mnemonic",
+    "crypto": {
+        "ciphertext": "6d70fbdceba874f56f15af4b1d060223799288cfc5d276d9ebb91732f5a38c3c59f83896fa7e7eb6a04c05475a6fe4d154de9b9441864c507abd0eb6987dac521b64c0c82783a3cd1e09270cd6cb5ae493f9af694b891253ac1f1ffded68b5ef39c972307e3c33a8354337540908acc795d4df72298dda1ca28ac920983e6a39a01e2bc988bd0b21f864c6de8b5356d11e4b77bc6f75ef",
+        "cipherparams": {
+            "iv": "2da5620906634972d9a623bc249d63d4"
+        },
+        "cipher": "aes-128-ctr",
+        "kdf": "scrypt",
+        "kdfparams": {
+            "dklen": 32,
+            "salt": "aa9e0ba6b188703071a582c10e5331f2756279feb0e2768f1ba0fd38ec77f035",
+            "n": 4096,
+            "r": 8,
+            "p": 1
+        },
+        "mac": "5bc1b20b6d903b8ef3273eedf028112d65eaf85a5ef4215917c1209ec2df715a"
+    }
+}

--- a/src/testdata/withoutKind.json
+++ b/src/testdata/withoutKind.json
@@ -1,6 +1,5 @@
 {
     "version": 4,
-    "kind": "secretKey",
     "id": "0dc10c02-b59b-4bac-9710-6b2cfa4284ba",
     "address": "0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1",
     "bech32": "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",

--- a/src/testutils/wallets.ts
+++ b/src/testutils/wallets.ts
@@ -5,6 +5,7 @@ import { readTestFile } from "./files";
 
 export const DummyPassword = "password";
 export const DummyMnemonic = "moral volcano peasant pass circle pen over picture flat shop clap goat never lyrics gather prepare woman film husband gravity behind test tiger improve";
+export const DummyMnemonicOf12Words = "matter trumpet twenty parade fame north lift sail valve salon foster cinnamon";
 
 export async function loadTestWallet(name: string): Promise<TestWallet> {
     let testdataPath = path.resolve(__dirname, "..", "testdata");

--- a/src/testutils/wallets.ts
+++ b/src/testutils/wallets.ts
@@ -8,15 +8,25 @@ export const DummyMnemonic = "moral volcano peasant pass circle pen over picture
 export const DummyMnemonicOf12Words = "matter trumpet twenty parade fame north lift sail valve salon foster cinnamon";
 
 export async function loadTestWallet(name: string): Promise<TestWallet> {
-    let testdataPath = path.resolve(__dirname, "..", "testdata");
-    let jsonFilePath = path.resolve(testdataPath, `${name}.json`);
-    let pemFilePath = path.resolve(testdataPath, `${name}.pem`);
+    const keystore = await loadTestKeystore(`${name}.json`)
+    const pemText = await loadTestPemFile(`${name}.pem`)
+    const pemKey = UserSecretKey.fromPem(pemText);
+    const address = new UserAddress(Buffer.from(keystore.address, "hex"));
 
-    let jsonWallet = JSON.parse(await readTestFile(jsonFilePath));
-    let pemText = await readTestFile(pemFilePath);
-    let pemKey = UserSecretKey.fromPem(pemText);
-    let address = new UserAddress(Buffer.from(jsonWallet.address, "hex"));
-    return new TestWallet(address, pemKey.hex(), jsonWallet, pemText);
+    return new TestWallet(address, pemKey.hex(), keystore, pemText);
+}
+
+export async function loadTestKeystore(file: string): Promise<any> {
+    const testdataPath = path.resolve(__dirname, "..", "testdata");
+    const keystorePath = path.resolve(testdataPath, file);
+    const json = await readTestFile(keystorePath);
+    return JSON.parse(json);
+}
+
+export async function loadTestPemFile(file: string): Promise<string> {
+    const testdataPath = path.resolve(__dirname, "..", "testdata");
+    const pemFilePath = path.resolve(testdataPath, file);
+    return await readTestFile(pemFilePath);
 }
 
 export class TestWallet {

--- a/src/userWallet.ts
+++ b/src/userWallet.ts
@@ -14,8 +14,7 @@ export enum EnvelopeVersion {
 
 export enum UserWalletKind {
     SecretKey = "secretKey",
-    Mnemonic = "mnemonic",
-    Arbitrary = "arbitrary"
+    Mnemonic = "mnemonic"
 }
 
 export class UserWallet {
@@ -100,34 +99,6 @@ export class UserWallet {
         });
     }
 
-    static fromArbitrary({
-        envelopeVersion,
-        encryptorVersion,
-        arbitraryData,
-        password,
-        randomness,
-    }: {
-        envelopeVersion?: EnvelopeVersion;
-        encryptorVersion?: EncryptorVersion;
-        arbitraryData: Buffer;
-        password: string;
-        randomness?: Randomness;
-    }): UserWallet {
-        envelopeVersion = envelopeVersion || EnvelopeVersion.V5;
-        encryptorVersion = encryptorVersion || EncryptorVersion.V4;
-        randomness = randomness || new Randomness();
-
-        requireVersion(envelopeVersion, [EnvelopeVersion.V5]);
-
-        const encryptedData = Encryptor.encrypt(encryptorVersion, arbitraryData, password, randomness);
-
-        return new UserWallet({
-            envelopeVersion: envelopeVersion,
-            kind: UserWalletKind.Arbitrary,
-            encryptedData
-        });
-    }
-
     /**
      * Copied from: https://github.com/multiversx/mx-deprecated-core-js/blob/v1.28.0/src/account.js#L42
      * Notes: adjustements (code refactoring, no change in logic), in terms of: 
@@ -166,15 +137,6 @@ export class UserWallet {
         return text.toString();
     }
 
-    static decryptArbitrary(keyFileObject: any, password: string): Buffer {
-        requireVersion(keyFileObject.version, [EnvelopeVersion.V5]);
-        requireKind(keyFileObject.kind, UserWalletKind.Arbitrary)
-
-        const encryptedData = UserWallet.edFromJSON(keyFileObject);
-        const data = Decryptor.decrypt(encryptedData, password);
-        return data;
-    }
-
     static edFromJSON(keyfileObject: any): EncryptedData {
         const encryptorVersion: number = (keyfileObject.version == EnvelopeVersion.V4) ?
             // In V4, the "crypto" section inherits the version from the envelope.
@@ -208,7 +170,7 @@ export class UserWallet {
             return this.getEnvelopeWhenKindIsSecretKey();
         }
 
-        return this.getEnvelopeWhenKindIsMnemonicOrArbitrary();
+        return this.getEnvelopeWhenKindIsMnemonic();
     }
 
     getEnvelopeWhenKindIsSecretKey(): any {
@@ -252,7 +214,7 @@ export class UserWallet {
         return cryptoSection;
     }
 
-    getEnvelopeWhenKindIsMnemonicOrArbitrary(): any {
+    getEnvelopeWhenKindIsMnemonic(): any {
         const cryptoSection = this.getCryptoSectionAsJSON();
 
         return {

--- a/src/userWallet.ts
+++ b/src/userWallet.ts
@@ -1,26 +1,125 @@
-import { CipherAlgorithm, Decryptor, EncryptedData, Encryptor, KeyDerivationFunction, Randomness, Version } from "./crypto";
+import { CipherAlgorithm, Decryptor, EncryptedData, Encryptor, EncryptorVersion, KeyDerivationFunction, Randomness } from "./crypto";
 import { ScryptKeyDerivationParams } from "./crypto/derivationParams";
+import { Err } from "./errors";
 import { UserPublicKey, UserSecretKey } from "./userKeys";
 
-export class UserWallet {
-    private readonly publicKey: UserPublicKey;
-    private readonly encryptedData: EncryptedData;
+export enum EnvelopeVersion {
+    // Does not have the "kind" field, and is meant to hold the **secret key**.
+    // The "crypto" section is not versioned.
+    V4 = 4,
+    // Has the "kind" field, and is meant to hold the **secret key** or **the mnemonic** (or any other secret payload).
+    // Furthermore, the "crypto" section is versioned separately.
+    V5 = 5
+}
 
-    /**
-     * Copied from: https://github.com/multiversx/mx-deprecated-core-js/blob/v1.28.0/src/account.js#L76
-     * Notes: adjustements (code refactoring, no change in logic), in terms of: 
-     *  - typing (since this is the TypeScript version)
-     *  - error handling (in line with sdk-core's error system)
-     *  - references to crypto functions
-     *  - references to object members
-     * 
-     * Given a password, generates the contents for a file containing the account's secret key,
-     * passed through a password-based key derivation function (kdf).
-     */
-    constructor(secretKey: UserSecretKey, password: string, randomness: Randomness = new Randomness()) {
-        const text = Buffer.concat([secretKey.valueOf(), secretKey.generatePublicKey().valueOf()]);
-        this.encryptedData = Encryptor.encrypt(text, password, randomness);
-        this.publicKey = secretKey.generatePublicKey();
+export enum UserWalletKind {
+    SecretKey = "secretKey",
+    Mnemonic = "mnemonic",
+    Arbitrary = "arbitrary"
+}
+
+export class UserWallet {
+    private readonly envelopeVersion: number;
+    private readonly kind: UserWalletKind;
+    private readonly encryptedData: EncryptedData;
+    private readonly publicKeyWhenKindIsSecretKey?: UserPublicKey;
+
+    private constructor({
+        envelopeVersion: envelopeVersion,
+        kind,
+        encryptedData,
+        publicKeyWhenKindIsSecretKey
+    }: {
+        envelopeVersion: EnvelopeVersion;
+        kind: UserWalletKind;
+        encryptedData: EncryptedData;
+        publicKeyWhenKindIsSecretKey?: UserPublicKey;
+    }) {
+        this.envelopeVersion = envelopeVersion;
+        this.kind = kind;
+        this.encryptedData = encryptedData;
+        this.publicKeyWhenKindIsSecretKey = publicKeyWhenKindIsSecretKey;
+    }
+
+    static fromSecretKey({
+        envelopeVersion,
+        encryptorVersion,
+        secretKey,
+        password,
+        randomness,
+    }: {
+        envelopeVersion?: EnvelopeVersion;
+        encryptorVersion?: EncryptorVersion;
+        secretKey: UserSecretKey;
+        password: string;
+        randomness?: Randomness;
+    }): UserWallet {
+        envelopeVersion = envelopeVersion || EnvelopeVersion.V4;
+        encryptorVersion = encryptorVersion || EncryptorVersion.V4;
+        randomness = randomness || new Randomness();
+
+        const publicKey = secretKey.generatePublicKey();
+        const text = Buffer.concat([secretKey.valueOf(), publicKey.valueOf()]);
+        const encryptedData = Encryptor.encrypt(encryptorVersion, text, password, randomness);
+
+        return new UserWallet({
+            envelopeVersion: envelopeVersion,
+            kind: UserWalletKind.SecretKey,
+            encryptedData,
+            publicKeyWhenKindIsSecretKey: publicKey
+        });
+    }
+
+    static fromMnemonic({
+        envelopeVersion,
+        encryptorVersion,
+        mnemonic,
+        password,
+        randomness,
+    }: {
+        envelopeVersion?: EnvelopeVersion;
+        encryptorVersion?: EncryptorVersion;
+        mnemonic: string;
+        password: string;
+        randomness?: Randomness;
+    }): UserWallet {
+        envelopeVersion = envelopeVersion || EnvelopeVersion.V5;
+        encryptorVersion = encryptorVersion || EncryptorVersion.V4;
+        randomness = randomness || new Randomness();
+
+        const encryptedData = Encryptor.encrypt(encryptorVersion, Buffer.from(mnemonic), password, randomness);
+
+        return new UserWallet({
+            envelopeVersion: envelopeVersion,
+            kind: UserWalletKind.Mnemonic,
+            encryptedData
+        });
+    }
+
+    static fromArbitrary({
+        envelopeVersion,
+        encryptorVersion,
+        arbitraryData,
+        password,
+        randomness,
+    }: {
+        envelopeVersion?: EnvelopeVersion;
+        encryptorVersion?: EncryptorVersion;
+        arbitraryData: Buffer;
+        password: string;
+        randomness?: Randomness;
+    }): UserWallet {
+        envelopeVersion = envelopeVersion || EnvelopeVersion.V5;
+        encryptorVersion = encryptorVersion || EncryptorVersion.V4;
+        randomness = randomness || new Randomness();
+
+        const encryptedData = Encryptor.encrypt(encryptorVersion, arbitraryData, password, randomness);
+
+        return new UserWallet({
+            envelopeVersion: envelopeVersion,
+            kind: UserWalletKind.Arbitrary,
+            encryptedData
+        });
     }
 
     /**
@@ -34,6 +133,10 @@ export class UserWallet {
      * From an encrypted keyfile, given the password, loads the secret key and the public key.
      */
     static decryptSecretKey(keyFileObject: any, password: string): UserSecretKey {
+        if (keyFileObject.version >= EnvelopeVersion.V5) {
+            this.requireKind(keyFileObject.kind, UserWalletKind.SecretKey, "decryptSecretKey")
+        }
+
         const encryptedData = UserWallet.edFromJSON(keyFileObject);
 
         let text = Decryptor.decrypt(encryptedData, password);
@@ -42,13 +145,37 @@ export class UserWallet {
             text = Buffer.concat([zeroPadding, text]);
         }
 
-        let seed = text.slice(0, 32);
+        const seed = text.slice(0, 32);
         return new UserSecretKey(seed);
     }
 
+    static decryptMnemonic(keyFileObject: any, password: string): string {
+        this.requireV5OrHigher(keyFileObject.version, "decryptMnemonic");
+        this.requireKind(keyFileObject.kind, UserWalletKind.Mnemonic, "decryptMnemonic")
+
+        const encryptedData = UserWallet.edFromJSON(keyFileObject);
+        const text = Decryptor.decrypt(encryptedData, password);
+        return text.toString();
+    }
+
+    static decryptArbitrary(keyFileObject: any, password: string): Buffer {
+        this.requireV5OrHigher(keyFileObject.version, "decryptArbitrary");
+        this.requireKind(keyFileObject.kind, UserWalletKind.Arbitrary, "decryptArbitrary")
+
+        const encryptedData = UserWallet.edFromJSON(keyFileObject);
+        const data = Decryptor.decrypt(encryptedData, password);
+        return data;
+    }
+
     static edFromJSON(keyfileObject: any): EncryptedData {
+        const encryptorVersion: number = (keyfileObject.version == EnvelopeVersion.V4) ?
+            // In V4, the "crypto" section inherits the version from the envelope.
+            EncryptorVersion.V4 :
+            // In V5, the "crypto" section has its own version.
+            keyfileObject.crypto.version;
+
         return new EncryptedData({
-            version: Version,
+            version: encryptorVersion,
             id: keyfileObject.id,
             cipher: keyfileObject.crypto.cipher,
             ciphertext: keyfileObject.crypto.ciphertext,
@@ -69,25 +196,74 @@ export class UserWallet {
      * Converts the encrypted keyfile to plain JavaScript object.
      */
     toJSON(): any {
-        return {
-            version: Version,
+        if (this.kind == UserWalletKind.SecretKey) {
+            return this.getEnvelopeWhenKindIsSecretKey();
+        }
+
+        return this.getEnvelopeWhenKindIsMnemonicOrArbitrary();
+    }
+
+    getEnvelopeWhenKindIsSecretKey(): any {
+        if (!this.publicKeyWhenKindIsSecretKey) {
+            throw new Err("Public key isn't available");
+        }
+
+        const cryptoSection = this.getCryptoSectionAsJSON();
+
+        const envelope: any = {
+            version: this.envelopeVersion,
+            // Adding "kind", if appropriate.
+            ...(this.envelopeVersion >= 5 ? { kind: UserWalletKind.SecretKey } : {}),
             id: this.encryptedData.id,
-            address: this.publicKey.hex(),
-            bech32: this.publicKey.toAddress().toString(),
-            crypto: {
-                ciphertext: this.encryptedData.ciphertext,
-                cipherparams: { iv: this.encryptedData.iv },
-                cipher: CipherAlgorithm,
-                kdf: KeyDerivationFunction,
-                kdfparams: {
-                    dklen: this.encryptedData.kdfparams.dklen,
-                    salt: this.encryptedData.salt,
-                    n: this.encryptedData.kdfparams.n,
-                    r: this.encryptedData.kdfparams.r,
-                    p: this.encryptedData.kdfparams.p
-                },
-                mac: this.encryptedData.mac,
-            }
+            address: this.publicKeyWhenKindIsSecretKey.hex(),
+            bech32: this.publicKeyWhenKindIsSecretKey.toAddress().toString(),
+            crypto: cryptoSection
         };
+
+        return envelope;
+    }
+
+    getCryptoSectionAsJSON(): any {
+        const cryptoSection: any = {
+            // Adding "version", if appropriate.
+            ...(this.envelopeVersion >= 5 ? { version: this.encryptedData.version } : {}),
+            ciphertext: this.encryptedData.ciphertext,
+            cipherparams: { iv: this.encryptedData.iv },
+            cipher: CipherAlgorithm,
+            kdf: KeyDerivationFunction,
+            kdfparams: {
+                dklen: this.encryptedData.kdfparams.dklen,
+                salt: this.encryptedData.salt,
+                n: this.encryptedData.kdfparams.n,
+                r: this.encryptedData.kdfparams.r,
+                p: this.encryptedData.kdfparams.p
+            },
+            mac: this.encryptedData.mac,
+        };
+
+        return cryptoSection;
+    }
+
+    getEnvelopeWhenKindIsMnemonicOrArbitrary(): any {
+        const cryptoSection = this.getCryptoSectionAsJSON();
+
+        return {
+            version: this.envelopeVersion,
+            id: this.encryptedData.id,
+            kind: this.kind,
+            crypto: cryptoSection
+        };
+    }
+
+    private static requireKind(kind: UserWalletKind, expectedKind: UserWalletKind, context: string) {
+        if (kind != expectedKind) {
+            throw new Err(`Expected kind to be ${expectedKind}, but it was ${kind}. Context: ${context}`);
+        }
+    }
+
+    private static requireV5OrHigher(version: EnvelopeVersion, context: string) {
+        if (version < EnvelopeVersion.V5) {
+            throw new Err(`Unsupported version: ${version}. Context: ${context}`);
+        }
     }
 }

--- a/src/users.spec.ts
+++ b/src/users.spec.ts
@@ -162,7 +162,7 @@ describe("test user wallets", () => {
         assert.equal(secretKeyV5.hex(), alice.secretKeyHex);
     });
 
-    it("should create and load keystore files (with mnemonics)", function () {
+    it.only("should create and load keystore files (with mnemonics)", function () {
         this.timeout(10000);
 
         const wallet = UserWallet.fromMnemonic({ mnemonic: DummyMnemonic, password: password });
@@ -171,6 +171,8 @@ describe("test user wallets", () => {
         assert.equal(json.version, 5);
         assert.equal(json.kind, "mnemonic");
         assert.isUndefined(json.bech32);
+
+        console.log(JSON.stringify(json, null, 4));
 
         const mnemonicText = UserWallet.decryptMnemonic(json, password);
         const mnemonic = Mnemonic.fromString(mnemonicText);
@@ -181,29 +183,14 @@ describe("test user wallets", () => {
         assert.equal(mnemonic.deriveKey(2).generatePublicKey().toAddress().bech32(), carol.address.bech32());
     });
 
-    it("should create and load keystore files (with arbitrary data)", function () {
-        const data = Buffer.from("hello");
-        const wallet = UserWallet.fromArbitrary({ arbitraryData: data, password: password });
-        const json = wallet.toJSON();
-
-        assert.equal(json.version, 5);
-        assert.equal(json.kind, "arbitrary");
-        assert.isUndefined(json.bech32);
-
-        const decryptedData = UserWallet.decryptArbitrary(json, password);
-        assert.deepEqual(decryptedData, data);
-    });
-
     it("should fail if using bad versions", function () {
         const aliceSecretKey = UserSecretKey.fromString(alice.secretKeyHex);
 
         assert.throws(() => UserWallet.fromSecretKey({ envelopeVersion: 7, secretKey: aliceSecretKey, password: password }), "Envelope version must be one of: [4, 5].");
         assert.throws(() => UserWallet.fromMnemonic({ envelopeVersion: 4, mnemonic: DummyMnemonic, password: password }), "Envelope version must be one of: [5].");
-        assert.throws(() => UserWallet.fromArbitrary({ envelopeVersion: 4, arbitraryData: Buffer.from(""), password: password }), "Envelope version must be one of: [5].");
 
         assert.throws(() => UserWallet.decryptSecretKey({ version: 3, crypto: {} }, password), "Envelope version must be one of: [4, 5].");
         assert.throws(() => UserWallet.decryptMnemonic({ version: 6, crypto: {} }, password), "Envelope version must be one of: [5].");
-        assert.throws(() => UserWallet.decryptArbitrary({ version: 7, crypto: {} }, password), "Envelope version must be one of: [5].");
     });
 
     it("should sign transactions", async () => {

--- a/src/users.spec.ts
+++ b/src/users.spec.ts
@@ -4,7 +4,7 @@ import { ErrInvariantFailed } from "./errors";
 import { Mnemonic } from "./mnemonic";
 import { TestMessage } from "./testutils/message";
 import { TestTransaction } from "./testutils/transaction";
-import { DummyMnemonic, DummyPassword, loadTestWallet, TestWallet } from "./testutils/wallets";
+import { DummyMnemonic, DummyMnemonicOf12Words, DummyPassword, loadTestWallet, TestWallet } from "./testutils/wallets";
 import { UserAddress } from "./userAddress";
 import { UserSecretKey } from "./userKeys";
 import { UserSigner } from "./userSigner";
@@ -33,6 +33,14 @@ describe("test user wallets", () => {
         assert.equal(mnemonic.deriveKey(0).hex(), alice.secretKeyHex);
         assert.equal(mnemonic.deriveKey(1).hex(), bob.secretKeyHex);
         assert.equal(mnemonic.deriveKey(2).hex(), carol.secretKeyHex);
+    });
+
+    it("should derive keys (12 words)", async () => {
+        const mnemonic = Mnemonic.fromString(DummyMnemonicOf12Words);
+
+        assert.equal(mnemonic.deriveKey(0).generatePublicKey().toAddress().bech32(), "erd1l8g9dk3gz035gkjhwegsjkqzdu3augrwhcfxrnucnyyrpc2220pqg4g7na");
+        assert.equal(mnemonic.deriveKey(1).generatePublicKey().toAddress().bech32(), "erd1fmhwg84rldg0xzngf53m0y607wvefvamh07n2mkypedx27lcqnts4zs09p");
+        assert.equal(mnemonic.deriveKey(2).generatePublicKey().toAddress().bech32(), "erd1tyuyemt4xz2yjvc7rxxp8kyfmk2n3h8gv3aavzd9ru4v2vhrkcksptewtj");
     });
 
     it("should create secret key", () => {

--- a/src/users.spec.ts
+++ b/src/users.spec.ts
@@ -156,8 +156,8 @@ describe("test user wallets", () => {
         assert.equal(json.kind, "mnemonic");
         assert.isUndefined(json.bech32);
 
-        const mnemonicText = UserWallet.decryptMnemonic(json, password);
-        const mnemonic = Mnemonic.fromString(mnemonicText);
+        const mnemonic = UserWallet.decryptMnemonic(json, password);
+        const mnemonicText = mnemonic.toString();
 
         assert.equal(mnemonicText, DummyMnemonic);
         assert.equal(mnemonic.deriveKey(0).generatePublicKey().toAddress().bech32(), alice.address.bech32());


### PR DESCRIPTION
Changes in keystore's structure:
 - add an extra field: `kind` (payload kind = secret key or mnemonic or arbitrary data).

**Keystore version remained v4.**

Newly generated regular keystore files with encrypted secret keys look as follows:

```
{
    "version": 4,
    "kind": "secretKey",
    ...
}
```

While keystore files with encrypted mnemonics look as follows:

```

{
    "version": 4,
    "kind": "mnemonic",
    ...
}
```