### PR TITLE
Simplified signature verification

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -23,10 +23,6 @@ export interface ISigner {
     sign(signable: ISignable): Promise<void>;
 }
 
-export interface IVerifier {
-    verify(message: IVerifiable): boolean;
-}
-
 /**
  * An interface that defines a signable object (e.g. a transaction).
  */
@@ -43,19 +39,4 @@ export interface ISignable {
      * @param signedBy The address of the {@link ISignature}
      */
     applySignature(signature: ISignature, signedBy: IAddress): void;
-}
-
-/**
- * Interface that defines a signed and verifiable object
- */
-export interface IVerifiable {
-    /**
-     * Returns the signature that should be verified
-     */
-    getSignature(): ISignature;
-
-    /**
-     * Returns the signable object in its raw form - a sequence of bytes to be verified.
-     */
-    serializeForSigning(signedBy?: IAddress): Buffer;
 }

--- a/src/testutils/message.ts
+++ b/src/testutils/message.ts
@@ -1,10 +1,9 @@
-import { IAddress, ISignable, ISignature, IVerifiable } from "../interface";
-import { Signature } from "../signature";
+import { IAddress, ISignature } from "../interface";
 
 /**
  * A dummy message used in tests.
  */
-export class TestMessage implements ISignable, IVerifiable {
+export class TestMessage {
     foo: string = "";
     bar: string = "";
     signature: string = "";
@@ -13,7 +12,7 @@ export class TestMessage implements ISignable, IVerifiable {
         Object.assign(this, init);
     }
 
-    serializeForSigning(_signedBy: IAddress): Buffer {
+    serializeForSigning(): Buffer {
         let plainObject = {
             foo: this.foo,
             bar: this.bar
@@ -25,9 +24,5 @@ export class TestMessage implements ISignable, IVerifiable {
 
     applySignature(signature: ISignature, _signedBy: IAddress): void {
         this.signature = signature.hex();
-    }
-
-    getSignature(): ISignature {
-        return new Signature(Buffer.from(this.signature, "hex"));
     }
 }

--- a/src/testutils/transaction.ts
+++ b/src/testutils/transaction.ts
@@ -1,10 +1,10 @@
-import { IAddress, ISignable, ISignature, IVerifiable } from "../interface";
+import { IAddress, ISignature } from "../interface";
 import { Signature } from "../signature";
 
 /**
  * A dummy transaction used in tests.
  */
-export class TestTransaction implements ISignable, IVerifiable {
+export class TestTransaction {
     nonce: number = 0;
     value: string = "";
     receiver: string = "";

--- a/src/userKeys.ts
+++ b/src/userKeys.ts
@@ -1,8 +1,8 @@
 import * as tweetnacl from "tweetnacl";
-import { UserAddress } from "./userAddress";
 import { guardLength } from "./assertions";
-import { parseUserKey } from "./pem";
 import { IAddress } from "./interface";
+import { parseUserKey } from "./pem";
+import { UserAddress } from "./userAddress";
 
 export const USER_SEED_LENGTH = 32;
 export const USER_PUBKEY_LENGTH = 32;
@@ -57,13 +57,13 @@ export class UserPublicKey {
 
     constructor(buffer: Buffer) {
         guardLength(buffer, USER_PUBKEY_LENGTH);
-        
+
         this.buffer = buffer;
     }
 
-    verify(message: Buffer, signature: Buffer): boolean {
+    verify(data: Buffer, signature: Buffer): boolean {
         try {
-            const unopenedMessage = Buffer.concat([signature, message]);
+            const unopenedMessage = Buffer.concat([signature, data]);
             const unsignedMessage = tweetnacl.sign.open(unopenedMessage, this.buffer);
             return unsignedMessage != null;
         } catch (err) {

--- a/src/userVerifier.ts
+++ b/src/userVerifier.ts
@@ -1,28 +1,28 @@
-import { IAddress, IVerifiable, IVerifier } from "./interface";
+import { IAddress } from "./interface";
 import { UserPublicKey } from "./userKeys";
 
 /**
  * ed25519 signature verification
  */
-export class UserVerifier implements IVerifier {
+export class UserVerifier {
 
   publicKey: UserPublicKey;
   constructor(publicKey: UserPublicKey) {
     this.publicKey = publicKey;
   }
 
-  static fromAddress(address: IAddress): IVerifier {
+  static fromAddress(address: IAddress): UserVerifier {
     let publicKey = new UserPublicKey(address.pubkey());
     return new UserVerifier(publicKey);
   }
 
   /**
-   * Verify a message's signature.
-   * @param message the message to be verified.
+   * 
+   * @param data the raw data to be verified (e.g. an already-serialized enveloped message)
+   * @param signature the signature to be verified
+   * @returns true if the signature is valid, false otherwise
    */
-  verify(message: IVerifiable): boolean {
-    return this.publicKey.verify(
-      message.serializeForSigning(this.publicKey.toAddress()),
-      Buffer.from(message.getSignature().hex(), 'hex'));
+  verify(data: Buffer, signature: Buffer): boolean {
+    return this.publicKey.verify(data, signature);
   }
 }

--- a/src/users.spec.ts
+++ b/src/users.spec.ts
@@ -200,7 +200,7 @@ describe("test user wallets", () => {
 
         assert.equal(serialized, `{"nonce":0,"value":"0","receiver":"erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r","sender":"erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz","gasPrice":1000000000,"gasLimit":50000,"data":"Zm9v","chainID":"1","version":1}`);
         assert.equal(transaction.getSignature().hex(), "b5fddb8c16fa7f6123cb32edc854f1e760a3eb62c6dc420b5a4c0473c58befd45b621b31a448c5b59e21428f2bc128c80d0ee1caa4f2bf05a12be857ad451b00");
-        assert.isTrue(verifier.verify(transaction));
+        assert.isTrue(verifier.verify(Buffer.from(serialized), Buffer.from(transaction.signature, "hex")));
         // Without data field
         transaction = new TestTransaction({
             nonce: 8,
@@ -235,7 +235,7 @@ describe("test user wallets", () => {
         assert.equal(transaction.getSignature().hex(), "c0bd2b3b33a07b9cc5ee7435228acb0936b3829c7008aacabceea35163e555e19a34def2c03a895cf36b0bcec30a7e11215c11efc0da29294a11234eb2b3b906");
     });
 
-    it("signs a general message", function () {
+    it("signs a general message", async function () {
         let signer = new UserSigner(UserSecretKey.fromString("1a927e2af5306a9bb2ea777f73e06ecc0ac9aaa72fb4ea3fecf659451394cccf"));
         let verifier = new UserVerifier(UserSecretKey.fromString("1a927e2af5306a9bb2ea777f73e06ecc0ac9aaa72fb4ea3fecf659451394cccf").generatePublicKey());
         const message = new TestMessage({
@@ -243,8 +243,12 @@ describe("test user wallets", () => {
             bar: "world"
         });
 
-        signer.sign(message);
+        await signer.sign(message);
+
+        const serialized = message.serializeForSigning();
+        const signature = Buffer.from(message.signature, "hex");
+
         assert.isNotEmpty(message.signature);
-        assert.isTrue(verifier.verify(message));
+        assert.isTrue(verifier.verify(serialized, signature));
     });
 });


### PR DESCRIPTION
Breaking change:
 - `verify(message: IVerifiable): boolean` changes to `verify(data: Buffer, signature: Buffer): boolean`.
 - dropped `IVerifiable`, `IVerifier` interfaces