### PR TITLE
Bit of decoupling: use interface "IUserSecretKey"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-wallet",
-      "version": "4.0.0-beta.1",
+      "version": "4.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "Wallet components for MultiversX",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/userSigner.ts
+++ b/src/userSigner.ts
@@ -3,13 +3,23 @@ import { UserAddress } from "./userAddress";
 import { UserSecretKey } from "./userKeys";
 import { UserWallet } from "./userWallet";
 
+interface IUserSecretKey {
+    sign(message: Buffer): Buffer;
+    generatePublicKey(): IUserPublicKey;
+}
+
+interface IUserPublicKey {
+    toAddress(): { bech32(): string; };
+}
+
+
 /**
  * ed25519 signer
  */
 export class UserSigner {
-    protected readonly secretKey: UserSecretKey;
+    protected readonly secretKey: IUserSecretKey;
 
-    constructor(secretKey: UserSecretKey) {
+    constructor(secretKey: IUserSecretKey) {
         this.secretKey = secretKey;
     }
 
@@ -36,6 +46,7 @@ export class UserSigner {
      * Gets the address of the signer.
      */
     getAddress(): UserAddress {
-        return this.secretKey.generatePublicKey().toAddress();
+        const bech32 = this.secretKey.generatePublicKey().toAddress().bech32();
+        return UserAddress.fromBech32(bech32);
     }
 }


### PR DESCRIPTION
Reason: allow dependent libraries to reference both `sdk-wallet v3` and `sdk-wallet v4` (at the same time), if desired (this was necessary in the integration tests of `sdk-js`).