### PR TITLE
Add benchmark for sign & verify (before switching to noble crypto libs)

### DIFF
--- a/src/usersBenchmark.spec.ts
+++ b/src/usersBenchmark.spec.ts
@@ -1,0 +1,53 @@
+import { assert } from "chai";
+import nacl from "tweetnacl";
+import { UserPublicKey, UserSecretKey } from "./userKeys";
+
+describe("behchmark sign and verify", () => {
+    it("should sign and verify", async function () {
+        this.timeout(60000);
+
+        const n = 1000;
+        const secretKeys: UserSecretKey[] = [];
+        const publicKeys: UserPublicKey[] = [];
+        const messages: Buffer[] = [];
+        const goodSignatures: Buffer[] = [];
+
+        for (let i = 0; i < n; i++) {
+            const secretKey = new UserSecretKey(Buffer.from(nacl.randomBytes(32)));
+            const publicKey = secretKey.generatePublicKey();
+            const message = Buffer.from(nacl.randomBytes(256));
+
+            secretKeys.push(secretKey);
+            publicKeys.push(publicKey);
+            messages.push(message);
+        }
+
+        console.info(`N = ${n}`);
+        console.time("sign");
+
+        for (let i = 0; i < n; i++) {
+            const signature = secretKeys[i].sign(messages[i]);
+            goodSignatures.push(signature);
+        }
+
+        console.timeEnd("sign");
+
+        console.time("verify (good)");
+
+        for (let i = 0; i < n; i++) {
+            const ok = publicKeys[i].verify(messages[i], goodSignatures[i]);
+            assert.isTrue(ok);
+        }
+
+        console.timeEnd("verify (good)");
+
+        console.time("verify (bad)");
+
+        for (let i = 0; i < n; i++) {
+            const ok = publicKeys[i].verify(messages[messages.length - i - 1], goodSignatures[i]);
+            assert.isFalse(ok);
+        }
+
+        console.timeEnd("verify (bad)");
+    });
+});


### PR DESCRIPTION
Time measurements for 1000 test points (sign, verify with good message, verify with bad message):

```
Node JS (v16.14.2)
 - sign: 8.851s (~9ms per operation)
 - verify (good): 8.927s (~9ms per operation)
 - verify (bad): 8.798s (~9ms per operation)

Browser (Firefox):
 - sign: 3992ms (~4ms per operation)
 - verify (good): 3973ms (~4ms per operation)
 - verify (bad): 3976ms (~4ms per operation)

Browser (Chrome):
 - sign: 5684.646728515625 ms (~6ms per operation)
 - verify (good): 5262.2490234375 ms (~5ms per operation)
 - verify (bad): 4686.670166015625 ms (~5ms per operation)
```

Used computer (laptop):

```
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
Address sizes:                   39 bits physical, 48 bits virtual
CPU(s):                          8
On-line CPU(s) list:             0-7
Thread(s) per core:              2
Core(s) per socket:              4
Socket(s):                       1
NUMA node(s):                    1
Vendor ID:                       GenuineIntel
CPU family:                      6
Model:                           140
Model name:                      11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
Stepping:                        1
CPU MHz:                         2800.000
CPU max MHz:                     4700,0000
CPU min MHz:                     400,0000
BogoMIPS:                        5606.40
L1d cache:                       192 KiB
L1i cache:                       128 KiB
L2 cache:                        5 MiB
L3 cache:                        12 MiB
NUMA node0 CPU(s):               0-7

```