### PR TITLE
Use noble-ed25519 for signing & verifying (user wallets)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",
+        "@noble/ed25519": "1.7.3",
+        "@noble/hashes": "1.3.0",
         "bech32": "1.1.4",
         "bip39": "3.0.2",
         "blake2b": "2.1.3",
@@ -473,6 +475,28 @@
       "engines": {
         "node": ">=8.9.0"
       }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@types/assert": {
       "version": "1.4.6",
@@ -4488,6 +4512,16 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@multiversx/sdk-bls-wasm/-/sdk-bls-wasm-0.3.5.tgz",
       "integrity": "sha512-c0tIdQUnbBLSt6NYU+OpeGPYdL0+GV547HeHT8Xc0BKQ7Cj0v82QUoA2QRtWrR1G4MNZmLsIacZSsf6DrIS2Bw=="
+    },
+    "@noble/ed25519": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ=="
+    },
+    "@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg=="
     },
     "@types/assert": {
       "version": "1.4.6",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "keccak": "3.0.1",
     "scryptsy": "2.1.0",
     "tweetnacl": "1.0.3",
+    "@noble/ed25519": "1.7.3",
+    "@noble/hashes": "1.3.0",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/src/crypto/pubkeyEncryptor.ts
+++ b/src/crypto/pubkeyEncryptor.ts
@@ -7,7 +7,7 @@ import { X25519EncryptedData } from "./x25519EncryptedData";
 
 export class PubkeyEncryptor {
     static encrypt(data: Buffer, recipientPubKey: UserPublicKey, authSecretKey: UserSecretKey): X25519EncryptedData {
-        // create a new x225519 keypair that will be used for EDH
+        // create a new x25519 keypair that will be used for EDH
         const edhPair = nacl.sign.keyPair();
         const recipientDHPubKey = ed2curve.convertPublicKey(recipientPubKey.valueOf());
         if (recipientDHPubKey === null) {

--- a/src/crypto/randomness.ts
+++ b/src/crypto/randomness.ts
@@ -1,5 +1,5 @@
-import nacl from "tweetnacl";
-import {v4 as uuidv4} from "uuid";
+import { utils } from "@noble/ed25519";
+import { v4 as uuidv4 } from "uuid";
 const crypto = require("crypto");
 
 export class Randomness {
@@ -8,8 +8,8 @@ export class Randomness {
   id: string;
 
   constructor(init?: Partial<Randomness>) {
-    this.salt = init?.salt || Buffer.from(nacl.randomBytes(32));
-    this.iv = init?.iv || Buffer.from(nacl.randomBytes(16));
+    this.salt = init?.salt || Buffer.from(utils.randomBytes(32));
+    this.iv = init?.iv || Buffer.from(utils.randomBytes(16));
     this.id = init?.id || uuidv4({ random: crypto.randomBytes(16) });
   }
 }

--- a/src/userKeys.ts
+++ b/src/userKeys.ts
@@ -1,10 +1,14 @@
-import * as tweetnacl from "tweetnacl";
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha512";
 import { guardLength } from "./assertions";
 import { parseUserKey } from "./pem";
 import { UserAddress } from "./userAddress";
 
 export const USER_SEED_LENGTH = 32;
 export const USER_PUBKEY_LENGTH = 32;
+
+// See: https://github.com/paulmillr/noble-ed25519
+ed.utils.sha512Sync = (...m) => sha512(ed.utils.concatBytes(...m));
 
 export class UserSecretKey {
     private readonly buffer: Buffer;
@@ -27,18 +31,12 @@ export class UserSecretKey {
     }
 
     generatePublicKey(): UserPublicKey {
-        let keyPair = tweetnacl.sign.keyPair.fromSeed(new Uint8Array(this.buffer));
-        let buffer = Buffer.from(keyPair.publicKey);
+        const buffer = ed.sync.getPublicKey(this.buffer);
         return new UserPublicKey(buffer);
     }
 
     sign(message: Buffer): Buffer {
-        let pair = tweetnacl.sign.keyPair.fromSeed(new Uint8Array(this.buffer));
-        let signingKey = pair.secretKey;
-        let signature = tweetnacl.sign(new Uint8Array(message), signingKey);
-        // "tweetnacl.sign()" returns the concatenated [signature, message], therfore we remove the appended message:
-        signature = signature.slice(0, signature.length - message.length);
-
+        const signature = ed.sync.sign(message, this.buffer);
         return Buffer.from(signature);
     }
 
@@ -54,18 +52,17 @@ export class UserSecretKey {
 export class UserPublicKey {
     private readonly buffer: Buffer;
 
-    constructor(buffer: Buffer) {
+    constructor(buffer: Uint8Array) {
         guardLength(buffer, USER_PUBKEY_LENGTH);
 
-        this.buffer = buffer;
+        this.buffer = Buffer.from(buffer);
     }
 
     verify(data: Buffer, signature: Buffer): boolean {
         try {
-            const unopenedMessage = Buffer.concat([signature, data]);
-            const unsignedMessage = tweetnacl.sign.open(unopenedMessage, this.buffer);
-            return unsignedMessage != null;
-        } catch (err) {
+            const ok = ed.sync.verify(signature, data, this.buffer);
+            return ok;
+        } catch (err: any) {
             console.error(err);
             return false;
         }

--- a/src/userKeys.ts
+++ b/src/userKeys.ts
@@ -8,6 +8,7 @@ export const USER_SEED_LENGTH = 32;
 export const USER_PUBKEY_LENGTH = 32;
 
 // See: https://github.com/paulmillr/noble-ed25519
+// In a future version of sdk-wallet, we'll switch to using the async functions of noble-ed25519.
 ed.utils.sha512Sync = (...m) => sha512(ed.utils.concatBytes(...m));
 
 export class UserSecretKey {

--- a/src/usersBenchmark.spec.ts
+++ b/src/usersBenchmark.spec.ts
@@ -1,0 +1,53 @@
+import { utils } from "@noble/ed25519";
+import { assert } from "chai";
+import { UserPublicKey, UserSecretKey } from "./userKeys";
+
+describe("behchmark sign and verify", () => {
+
+    it.only("should sign and verify", async function () {
+        this.timeout(60000);
+
+        const n = 10000;
+        const secretKeys: UserSecretKey[] = [];
+        const publicKeys: UserPublicKey[] = [];
+        const messages: Buffer[] = [];
+        const goodSignatures: Buffer[] = [];
+
+        for (let i = 0; i < n; i++) {
+            const secretKey = new UserSecretKey(Buffer.from(utils.randomBytes(32)));
+            const publicKey = secretKey.generatePublicKey();
+            const message = Buffer.from(utils.randomBytes(256));
+
+            secretKeys.push(secretKey);
+            publicKeys.push(publicKey);
+            messages.push(message);
+        }
+
+        console.time("sign");
+
+        for (let i = 0; i < n; i++) {
+            const signature = secretKeys[i].sign(messages[i]);
+            goodSignatures.push(signature);
+        }
+
+        console.timeEnd("sign");
+
+        console.time("verify (good)");
+
+        for (let i = 0; i < n; i++) {
+            const ok = publicKeys[i].verify(messages[i], goodSignatures[i]);
+            assert.isTrue(ok);
+        }
+
+        console.timeEnd("verify (good)");
+
+        console.time("verify (bad)");
+
+        for (let i = 0; i < n; i++) {
+            const ok = publicKeys[i].verify(messages[messages.length - i - 1], goodSignatures[i]);
+            assert.isFalse(ok);
+        }
+
+        console.timeEnd("verify (bad)");
+    });
+});

--- a/src/usersBenchmark.spec.ts
+++ b/src/usersBenchmark.spec.ts
@@ -22,6 +22,8 @@ describe("behchmark sign and verify", () => {
             messages.push(message);
         }
 
+        console.info(`N = ${n}`);
+
         console.time("sign");
 
         for (let i = 0; i < n; i++) {


### PR DESCRIPTION
Switched to using `@noble/ed25519` for signing and verifying data (for user wallets, not for validator wallets - that will come in a separate PR). We could not completely remove the `tweetnacl` dependency, however - it's still used by `pubkeyEncryptor` and `pubkeyDecryptor`.

Note that we're using the `sync` variants of `@noble/ed25519`'s functions. Thus, we also had to shim `ed.utils.sha512Sync`. In a future PR (possibly wallet v5) we'll switch to the async variants.

----

Benchmark (sketch) for `tweetnacl` is here: https://github.com/multiversx/mx-sdk-js-wallet/pull/26

Below, benchmark using `noble-ed25519`.

Time measurements for 1000 test points (sign, verify with good message, verify with bad message):

```
Node JS (v16.14.2):
 - sign: 356.763ms (0.3ms per operation)  - 30x improvement
 - verify (good):  (1.5ms per operation) - 6x improvement
 - verify (bad):  (1.5ms per operation) - 6x improvement

Browser (Firefox):
 - sign: 443ms  (0.4ms per operation) - 10x improvement
 - verify (good): 1821ms  (1.8ms per operation) - 2x improvement
 - verify (bad): 1852ms (1.8ms per operation)  - 2x improvement

Browser (Chrome):
 - sign: 246.4248046875 ms (0.25ms per operation) - 24x improvement
 - verify (good): (1ms per operation) - 5x improvement
 - verify (bad): (1ms per operation) - 5x improvement
```

Used computer (laptop):

```
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
Address sizes:                   39 bits physical, 48 bits virtual
CPU(s):                          8
On-line CPU(s) list:             0-7
Thread(s) per core:              2
Core(s) per socket:              4
Socket(s):                       1
NUMA node(s):                    1
Vendor ID:                       GenuineIntel
CPU family:                      6
Model:                           140
Model name:                      11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
Stepping:                        1
CPU MHz:                         2800.000
CPU max MHz:                     4700,0000
CPU min MHz:                     400,0000
BogoMIPS:                        5606.40
L1d cache:                       192 KiB
L1i cache:                       128 KiB
L2 cache:                        5 MiB
L3 cache:                        12 MiB
NUMA node0 CPU(s):               0-7

```