### PR TITLE
Automatically handle both kinds of keystores in "UserWallet.loadSecretKey(), "UserSigner.fromWallet()"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-wallet",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Wallet components for MultiversX",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/userSigner.ts
+++ b/src/userSigner.ts
@@ -24,7 +24,7 @@ export class UserSigner {
     }
 
     static fromWallet(keyFileObject: any, password: string, addressIndex?: number): UserSigner {
-        const secretKey = UserWallet.loadSecretKey(keyFileObject, password, addressIndex);
+        const secretKey = UserWallet.decrypt(keyFileObject, password, addressIndex);
         return new UserSigner(secretKey);
     }
 

--- a/src/userSigner.ts
+++ b/src/userSigner.ts
@@ -23,8 +23,8 @@ export class UserSigner {
         this.secretKey = secretKey;
     }
 
-    static fromWallet(keyFileObject: any, password: string): UserSigner {
-        let secretKey = UserWallet.decryptSecretKey(keyFileObject, password);
+    static fromWallet(keyFileObject: any, password: string, addressIndex?: number): UserSigner {
+        const secretKey = UserWallet.loadSecretKey(keyFileObject, password, addressIndex);
         return new UserSigner(secretKey);
     }
 

--- a/src/userWallet.ts
+++ b/src/userWallet.ts
@@ -65,7 +65,7 @@ export class UserWallet {
         });
     }
 
-    static loadSecretKey(keyFileObject: any, password: string, addressIndex?: number): UserSecretKey {
+    static decrypt(keyFileObject: any, password: string, addressIndex?: number): UserSecretKey {
         const kind = keyFileObject.kind || UserWalletKind.SecretKey;
 
         if (kind == UserWalletKind.SecretKey) {

--- a/src/userWallet.ts
+++ b/src/userWallet.ts
@@ -65,6 +65,25 @@ export class UserWallet {
         });
     }
 
+    static loadSecretKey(keyFileObject: any, password: string, addressIndex?: number): UserSecretKey {
+        const kind = keyFileObject.kind || UserWalletKind.SecretKey;
+
+        if (kind == UserWalletKind.SecretKey) {
+            if (addressIndex !== undefined) {
+                throw new Err("addressIndex must not be provided when kind == 'secretKey'");
+            }
+
+            return UserWallet.decryptSecretKey(keyFileObject, password);
+        }
+
+        if (kind == UserWalletKind.Mnemonic) {
+            const mnemonic = this.decryptMnemonic(keyFileObject, password);
+            return mnemonic.deriveKey(addressIndex || 0);
+        }
+
+        throw new Err(`Unknown kind: ${kind}`);
+    }
+
     /**
      * Copied from: https://github.com/multiversx/mx-deprecated-core-js/blob/v1.28.0/src/account.js#L42
      * Notes: adjustements (code refactoring, no change in logic), in terms of: 

--- a/src/users.spec.ts
+++ b/src/users.spec.ts
@@ -178,6 +178,27 @@ describe("test user wallets", () => {
         assert.deepEqual(dummyWallet.toJSON(), expectedDummyWallet);
     });
 
+    it("should loadSecretKey, but without 'kind' field", async function () {
+        const keyFileObject = await loadTestKeystore("withoutKind.json");
+        const secretKey = UserWallet.loadSecretKey(keyFileObject, password);
+
+        assert.equal(secretKey.generatePublicKey().toAddress().bech32(), "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
+    });
+
+    it("should throw when calling loadSecretKey with unecessary address index", async function () {
+        const keyFileObject = await loadTestKeystore("alice.json");
+
+        assert.throws(() => UserWallet.loadSecretKey(keyFileObject, password, 42), "addressIndex must not be provided when kind == 'secretKey'");
+    });
+
+    it("should loadSecretKey with mnemonic", async function () {
+        const keyFileObject = await loadTestKeystore("withDummyMnemonic.json");
+
+        assert.equal(UserWallet.loadSecretKey(keyFileObject, password, 0).generatePublicKey().toAddress().bech32(), "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
+        assert.equal(UserWallet.loadSecretKey(keyFileObject, password, 1).generatePublicKey().toAddress().bech32(), "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx");
+        assert.equal(UserWallet.loadSecretKey(keyFileObject, password, 2).generatePublicKey().toAddress().bech32(), "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8");
+    });
+
     it("should sign transactions", async () => {
         let signer = new UserSigner(UserSecretKey.fromString("1a927e2af5306a9bb2ea777f73e06ecc0ac9aaa72fb4ea3fecf659451394cccf"));
         let verifier = new UserVerifier(UserSecretKey.fromString("1a927e2af5306a9bb2ea777f73e06ecc0ac9aaa72fb4ea3fecf659451394cccf").generatePublicKey());

--- a/src/users.spec.ts
+++ b/src/users.spec.ts
@@ -323,4 +323,15 @@ describe("test user wallets", () => {
         assert.isTrue(verifier.verify(data, signature));
         assert.isFalse(verifier.verify(Buffer.from("hello"), signature));
     });
+
+    it("should create UserSigner from wallet", async function () {
+        const keyFileObjectWithoutKind = await loadTestKeystore("withoutKind.json");
+        const keyFileObjectWithMnemonic = await loadTestKeystore("withDummyMnemonic.json");
+
+        assert.equal(UserSigner.fromWallet(keyFileObjectWithoutKind, password).getAddress().bech32(), "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
+        assert.equal(UserSigner.fromWallet(keyFileObjectWithMnemonic, password).getAddress().bech32(), "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
+        assert.equal(UserSigner.fromWallet(keyFileObjectWithMnemonic, password, 0).getAddress().bech32(), "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
+        assert.equal(UserSigner.fromWallet(keyFileObjectWithMnemonic, password, 1).getAddress().bech32(), "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx");
+        assert.equal(UserSigner.fromWallet(keyFileObjectWithMnemonic, password, 2).getAddress().bech32(), "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8");
+    });
 });

--- a/src/users.spec.ts
+++ b/src/users.spec.ts
@@ -180,7 +180,7 @@ describe("test user wallets", () => {
 
     it("should loadSecretKey, but without 'kind' field", async function () {
         const keyFileObject = await loadTestKeystore("withoutKind.json");
-        const secretKey = UserWallet.loadSecretKey(keyFileObject, password);
+        const secretKey = UserWallet.decrypt(keyFileObject, password);
 
         assert.equal(secretKey.generatePublicKey().toAddress().bech32(), "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
     });
@@ -188,15 +188,15 @@ describe("test user wallets", () => {
     it("should throw when calling loadSecretKey with unecessary address index", async function () {
         const keyFileObject = await loadTestKeystore("alice.json");
 
-        assert.throws(() => UserWallet.loadSecretKey(keyFileObject, password, 42), "addressIndex must not be provided when kind == 'secretKey'");
+        assert.throws(() => UserWallet.decrypt(keyFileObject, password, 42), "addressIndex must not be provided when kind == 'secretKey'");
     });
 
     it("should loadSecretKey with mnemonic", async function () {
         const keyFileObject = await loadTestKeystore("withDummyMnemonic.json");
 
-        assert.equal(UserWallet.loadSecretKey(keyFileObject, password, 0).generatePublicKey().toAddress().bech32(), "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
-        assert.equal(UserWallet.loadSecretKey(keyFileObject, password, 1).generatePublicKey().toAddress().bech32(), "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx");
-        assert.equal(UserWallet.loadSecretKey(keyFileObject, password, 2).generatePublicKey().toAddress().bech32(), "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8");
+        assert.equal(UserWallet.decrypt(keyFileObject, password, 0).generatePublicKey().toAddress().bech32(), "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
+        assert.equal(UserWallet.decrypt(keyFileObject, password, 1).generatePublicKey().toAddress().bech32(), "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx");
+        assert.equal(UserWallet.decrypt(keyFileObject, password, 2).generatePublicKey().toAddress().bech32(), "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8");
     });
 
     it("should sign transactions", async () => {


### PR DESCRIPTION

Fixes https://github.com/multiversx/mx-sdk-js-wallet/issues/37.

Also see: https://github.com/multiversx/mx-sdk-py-wallet/pull/18.