### PR TITLE
Added extra check when decrypting secret key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-wallet",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Wallet components for MultiversX",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/userWallet.ts
+++ b/src/userWallet.ts
@@ -95,7 +95,11 @@ export class UserWallet {
      * From an encrypted keyfile, given the password, loads the secret key and the public key.
      */
     static decryptSecretKey(keyFileObject: any, password: string): UserSecretKey {
-        // Here, we do not check the "kind" field. Older keystore files (holding only secret keys) do not have this field.
+        // Here, we check the "kind" field only for files that have it. Older keystore files (holding only secret keys) do not have this field.
+        const kind = keyFileObject.kind;
+        if (kind && kind !== UserWalletKind.SecretKey){
+            throw new Err(`Expected kind to be ${UserWalletKind.SecretKey}, but it was ${kind}.`);
+        }
 
         const encryptedData = UserWallet.edFromJSON(keyFileObject);
 

--- a/src/users.spec.ts
+++ b/src/users.spec.ts
@@ -334,4 +334,16 @@ describe("test user wallets", () => {
         assert.equal(UserSigner.fromWallet(keyFileObjectWithMnemonic, password, 1).getAddress().bech32(), "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx");
         assert.equal(UserSigner.fromWallet(keyFileObjectWithMnemonic, password, 2).getAddress().bech32(), "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8");
     });
+
+    it.only("should throw error when decrypting secret key with keystore-mnemonic file", async function () {
+        const userWallet = UserWallet.fromMnemonic({
+            mnemonic: DummyMnemonic,
+            password: ``
+        });
+        const keystoreMnemonic = userWallet.toJSON();
+
+        assert.throws(() => {
+            UserWallet.decryptSecretKey(keystoreMnemonic, ``)
+        }, `Expected kind to be secretKey, but it was mnemonic.`);
+    });
 });

--- a/src/users.spec.ts
+++ b/src/users.spec.ts
@@ -335,7 +335,7 @@ describe("test user wallets", () => {
         assert.equal(UserSigner.fromWallet(keyFileObjectWithMnemonic, password, 2).getAddress().bech32(), "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8");
     });
 
-    it.only("should throw error when decrypting secret key with keystore-mnemonic file", async function () {
+    it("should throw error when decrypting secret key with keystore-mnemonic file", async function () {
         const userWallet = UserWallet.fromMnemonic({
             mnemonic: DummyMnemonic,
             password: ``


### PR DESCRIPTION
Because there was no check for the `kind` field when calling `UserWallet.decryptSecretKey()` one could have passed a `keystore-mnemonic` file. There is still a limitation for older files that do not contain that field.