### PR TITLE
Accept "Uint8Array", in addition to "Buffer" (on the main flows: sign, verify)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-wallet",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Wallet components for MultiversX",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -4,8 +4,8 @@
 export class Signature {
     private readonly buffer: Buffer;
 
-    constructor(buffer: Buffer) {
-        this.buffer = buffer;
+    constructor(buffer: Buffer | Uint8Array) {
+        this.buffer = Buffer.from(buffer);
     }
 
     hex() {

--- a/src/userKeys.ts
+++ b/src/userKeys.ts
@@ -36,7 +36,7 @@ export class UserSecretKey {
         return new UserPublicKey(buffer);
     }
 
-    sign(message: Buffer): Buffer {
+    sign(message: Buffer | Uint8Array): Buffer {
         const signature = ed.sync.sign(new Uint8Array(message), new Uint8Array(this.buffer));
         return Buffer.from(signature);
     }
@@ -59,7 +59,7 @@ export class UserPublicKey {
         this.buffer = Buffer.from(buffer);
     }
 
-    verify(data: Buffer, signature: Buffer): boolean {
+    verify(data: Buffer | Uint8Array, signature: Buffer | Uint8Array): boolean {
         try {
             const ok = ed.sync.verify(new Uint8Array(signature), new Uint8Array(data), new Uint8Array(this.buffer));
             return ok;

--- a/src/userSigner.ts
+++ b/src/userSigner.ts
@@ -4,7 +4,7 @@ import { UserSecretKey } from "./userKeys";
 import { UserWallet } from "./userWallet";
 
 interface IUserSecretKey {
-    sign(message: Buffer): Buffer;
+    sign(message: Buffer | Uint8Array): Buffer;
     generatePublicKey(): IUserPublicKey;
 }
 
@@ -33,7 +33,7 @@ export class UserSigner {
         return new UserSigner(secretKey);
     }
 
-    async sign(data: Buffer): Promise<Buffer> {
+    async sign(data: Buffer | Uint8Array): Promise<Buffer> {
         try {
             const signature = this.secretKey.sign(data);
             return signature;

--- a/src/userVerifier.ts
+++ b/src/userVerifier.ts
@@ -25,7 +25,7 @@ export class UserVerifier {
    * @param signature the signature to be verified
    * @returns true if the signature is valid, false otherwise
    */
-  verify(data: Buffer, signature: Buffer): boolean {
+  verify(data: Buffer | Uint8Array, signature: Buffer | Uint8Array): boolean {
     return this.publicKey.verify(data, signature);
   }
 }

--- a/src/users.spec.ts
+++ b/src/users.spec.ts
@@ -43,11 +43,13 @@ describe("test user wallets", () => {
     });
 
     it("should create secret key", () => {
-        let keyHex = alice.secretKeyHex;
-        let fromBuffer = new UserSecretKey(Buffer.from(keyHex, "hex"));
-        let fromHex = UserSecretKey.fromString(keyHex);
+        const keyHex = alice.secretKeyHex;
+        const fromBuffer = new UserSecretKey(Buffer.from(keyHex, "hex"));
+        const fromArray = new UserSecretKey(Uint8Array.from(Buffer.from(keyHex, "hex")));
+        const fromHex = UserSecretKey.fromString(keyHex);
 
         assert.equal(fromBuffer.hex(), keyHex);
+        assert.equal(fromArray.hex(), keyHex);
         assert.equal(fromHex.hex(), keyHex);
     });
 
@@ -217,9 +219,11 @@ describe("test user wallets", () => {
         let serialized = transaction.serializeForSigning();
         let signature = await signer.sign(serialized);
 
+        assert.deepEqual(await signer.sign(serialized), await signer.sign(Uint8Array.from(serialized)));
         assert.equal(serialized.toString(), `{"nonce":0,"value":"0","receiver":"erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r","sender":"","gasPrice":1000000000,"gasLimit":50000,"data":"Zm9v","chainID":"1","version":1}`);
         assert.equal(signature.toString("hex"), "a3b61a2fe461f3393c42e6cb0477a6b52ffd92168f10c111f6aa8d0a310ee0c314fae0670f8313f1ad992933ac637c61a8ff20cc20b6a8b2260a4af1a120a70d");
         assert.isTrue(verifier.verify(serialized, signature));
+        
         // Without data field
         transaction = new TestTransaction({
             nonce: 8,
@@ -233,6 +237,7 @@ describe("test user wallets", () => {
         serialized = transaction.serializeForSigning();
         signature = await signer.sign(serialized);
 
+        assert.deepEqual(await signer.sign(serialized), await signer.sign(Uint8Array.from(serialized)));
         assert.equal(serialized.toString(), `{"nonce":8,"value":"10000000000000000000","receiver":"erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r","sender":"","gasPrice":1000000000,"gasLimit":50000,"chainID":"1","version":1}`);
         assert.equal(signature.toString("hex"), "f136c901d37349a7da8cfe3ab5ec8ef333b0bc351517c0e9bef9eb9704aed3077bf222769cade5ff29dffe5f42e4f0c5e0b068bdba90cd2cb41da51fd45d5a03");
     });
@@ -304,7 +309,10 @@ describe("test user wallets", () => {
             chainID: "1"
         });
 
-        const signature = await signer.sign(transaction.serializeForSigning());
+        const serialized = transaction.serializeForSigning();
+        const signature = await signer.sign(serialized);
+
+        assert.deepEqual(await signer.sign(serialized), await signer.sign(Uint8Array.from(serialized)));
         assert.equal(signature.toString("hex"), "ba4fa95fea1402e4876abf1d5a510615aab374ee48bb76f5230798a7d3f2fcae6ba91ba56c6d62e6e7003ce531ff02f219cb7218dd00dd2ca650ba747f19640a");
     });
 
@@ -320,8 +328,11 @@ describe("test user wallets", () => {
         const data = message.serializeForSigning();
         const signature = await signer.sign(data);
 
+        assert.deepEqual(await signer.sign(data), await signer.sign(Uint8Array.from(data)));
         assert.isTrue(verifier.verify(data, signature));
+        assert.isTrue(verifier.verify(Uint8Array.from(data), Uint8Array.from(signature)));
         assert.isFalse(verifier.verify(Buffer.from("hello"), signature));
+        assert.isFalse(verifier.verify(new TextEncoder().encode("hello"), signature));
     });
 
     it("should create UserSigner from wallet", async function () {

--- a/src/validatorKeys.ts
+++ b/src/validatorKeys.ts
@@ -31,7 +31,7 @@ export class ValidatorSecretKey {
     private readonly secretKey: any;
     private readonly publicKey: any;
 
-    constructor(buffer: Buffer) {
+    constructor(buffer: Buffer | Uint8Array) {
         BLS.guardInitialized();
         guardLength(buffer, VALIDATOR_SECRETKEY_LENGTH);
 
@@ -49,7 +49,7 @@ export class ValidatorSecretKey {
         return new ValidatorPublicKey(buffer);
     }
 
-    sign(message: Buffer): Buffer {
+    sign(message: Buffer | Uint8Array): Buffer {
         let signatureObject = this.secretKey.sign(message);
         let signature = Buffer.from(signatureObject.serialize());
         return signature;
@@ -67,10 +67,10 @@ export class ValidatorSecretKey {
 export class ValidatorPublicKey {
     private readonly buffer: Buffer;
 
-    constructor(buffer: Buffer) {
+    constructor(buffer: Buffer | Uint8Array) {
         guardLength(buffer, VALIDATOR_PUBKEY_LENGTH);
 
-        this.buffer = buffer;
+        this.buffer = Buffer.from(buffer);
     }
 
     hex(): string {

--- a/src/validatorSigner.ts
+++ b/src/validatorSigner.ts
@@ -8,7 +8,7 @@ export class ValidatorSigner {
     /**
      * Signs a message.
      */
-    async signUsingPem(pemText: string, pemIndex: number = 0, signable: Buffer): Promise<void> {
+    async signUsingPem(pemText: string, pemIndex: number = 0, signable: Buffer | Uint8Array): Promise<void> {
         await BLS.initIfNecessary();
 
         try {

--- a/src/validators.spec.ts
+++ b/src/validators.spec.ts
@@ -8,16 +8,24 @@ describe("test validator keys", () => {
 
         let secretKey = Buffer.from(Buffer.from("N2NmZjk5YmQ2NzE1MDJkYjdkMTViYzhhYmMwYzlhODA0ZmI5MjU0MDZmYmRkNTBmMWU0YzE3YTRjZDc3NDI0Nw==", "base64").toString(), "hex");
         let key = new ValidatorSecretKey(secretKey);
+        
+        assert.deepEqual(new ValidatorSecretKey(secretKey), new ValidatorSecretKey(Uint8Array.from(secretKey)));
         assert.equal(key.generatePublicKey().hex(), "e7beaa95b3877f47348df4dd1cb578a4f7cabf7a20bfeefe5cdd263878ff132b765e04fef6f40c93512b666c47ed7719b8902f6c922c04247989b7137e837cc81a62e54712471c97a2ddab75aa9c2f58f813ed4c0fa722bde0ab718bff382208");
 
-        let signature = key.sign(Buffer.from("hello"));
+        const data = Buffer.from("hello");
+
+        let signature = key.sign(data);
+
+        assert.deepEqual(key.sign(data), key.sign(Uint8Array.from(data)));
         assert.equal(signature.toString("hex"), "84fd0a3a9d4f1ea2d4b40c6da67f9b786284a1c3895b7253fec7311597cda3f757862bb0690a92a13ce612c33889fd86");
 
         secretKey = Buffer.from(Buffer.from("ODA4NWJhMWQ3ZjdjM2RiOTM4YWQ3MDU5NWEyYmRhYjA5NjQ0ZjFlYzM4MDNiZTE3MWMzM2YxNGJjODBkNGUzYg==", "base64").toString(), "hex");
         key = new ValidatorSecretKey(secretKey);
         assert.equal(key.generatePublicKey().hex(), "78689fd4b1e2e434d567fe01e61598a42717d83124308266bd09ccc15d2339dd318c019914b86ac29adbae5dd8a02d0307425e9bd85a296e94943708c72f8c670f0b7c50a890a5719088dbd9f1d062cad9acffa06df834106eebe1a4257ef00d");
 
-        signature = key.sign(Buffer.from("hello"));
+        signature = key.sign(data);
+
+        assert.deepEqual(key.sign(data), key.sign(Uint8Array.from(data)));
         assert.equal(signature.toString("hex"), "be2e593ff10899a2ee8e1d5c8094e36c9f48e04b87e129991ff09475808743e07bb41bf6e7bc1463fa554c4b46594b98");
     });
 


### PR DESCRIPTION
This allows for easier calling `sign` and `verify` when the data to be signed / verified comes from the js-core V13's `computer.computeBytesForSigning()`. Otherwise, the client code should have wrapped the outcome of `computeBytesForSigning()` into a `Buffer`.

Related to: https://github.com/multiversx/mx-sdk-js-wallet/issues/31.

Also see:
 - https://github.com/multiversx/mx-sdk-specs/blob/main/core/transaction.md#transactioncomputer
 - https://github.com/multiversx/mx-sdk-specs/blob/main/core/message.md#messagecomputer