### PR TITLE
Add support for custom HRP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ out-tests
 out-browser
 node_modules/
 tags
+coverage/
+.nyc_output

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MultiversX SDK for JavaScript and TypeScript: wallet components
 
-Wallet components (generation, signing) for TypeScript (JavaScript). 
+Wallet components (generation, signing) for TypeScript (JavaScript).
 
 ## Distribution
 
@@ -17,6 +17,14 @@ npm install @multiversx/sdk-wallet
 ## Development
 
 Feel free to skip this section if you are not a contributor.
+
+### Additional dependencies
+
+Instanbul, for code coverage:
+
+```
+npm install --no-save nyc
+```
 
 ### Building the library
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.5.0",
+  "version": "4.5.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-wallet",
-      "version": "4.5.0",
+      "version": "4.5.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.5.0-beta.1",
+  "version": "4.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-wallet",
-      "version": "4.5.0-beta.1",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.5.0-beta.0",
+  "version": "4.5.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-wallet",
-      "version": "4.5.0-beta.0",
+      "version": "4.5.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-wallet",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.5.0",
+  "version": "4.5.0-beta.0",
   "description": "Wallet components for MultiversX",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Wallet components for MultiversX",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "test": "mocha",
+    "test-with-coverage": "nyc --reporter=html mocha",
     "compile-browser": "bash ./scripts/compile_browser.sh",
     "compile": "tsc -p tsconfig.json",
     "browser-tests": "bash ./scripts/browser_tests.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.5.0-beta.1",
+  "version": "4.5.0",
   "description": "Wallet components for MultiversX",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-wallet",
-  "version": "4.5.0-beta.0",
+  "version": "4.5.0-beta.1",
   "description": "Wallet components for MultiversX",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,15 @@
+/**
+ * Global configuration of the library.
+ *
+ * Generally speaking, this configuration should only be altered on exotic use cases;
+ * it can be seen as a collection of constants (or, to be more precise, rarely changed variables) that are used throughout the library.
+ *
+ * Never alter the configuration within a library!
+ * Only alter the configuration (if needed) within an (end) application that uses this library.
+ */
+export class LibraryConfig {
+    /**
+     * The human-readable-part of the bech32 addresses.
+     */
+    public static DefaultAddressHrp: string = "erd";
+}

--- a/src/userAddress.ts
+++ b/src/userAddress.ts
@@ -26,7 +26,7 @@ export class UserAddress {
 
     /**
      * @internal
-     * For internal use only.
+     * @deprecated
      */
     static fromBech32(value: string): UserAddress {
         // On this legacy flow, we do not accept addresses with custom hrp (in order to avoid behavioral breaking changes).

--- a/src/userAddress.ts
+++ b/src/userAddress.ts
@@ -4,16 +4,18 @@ import { ErrBadAddress } from "./errors";
 /**
  * The human-readable-part of the bech32 addresses.
  */
-const HRP = "erd";
+const DEFAULT_HRP = "erd";
 
 /**
  * A user Address, as an immutable object.
  */
 export class UserAddress {
     private readonly buffer: Buffer;
+    private readonly hrp: string;
 
-    public constructor(buffer: Buffer) {
+    public constructor(buffer: Buffer, hrp?: string) {
         this.buffer = buffer;
+        this.hrp = hrp || DEFAULT_HRP;
     }
 
     static fromBech32(value: string): UserAddress {
@@ -25,12 +27,12 @@ export class UserAddress {
             throw new ErrBadAddress(value, err);
         }
 
-        if (decoded.prefix != HRP) {
+        if (decoded.prefix != DEFAULT_HRP) {
             throw new ErrBadAddress(value);
         }
 
         let pubkey = Buffer.from(bech32.fromWords(decoded.words));
-        return new UserAddress(pubkey);
+        return new UserAddress(pubkey, decoded.prefix);
     }
 
     /**
@@ -44,8 +46,8 @@ export class UserAddress {
      * Returns the bech32 representation of the address
      */
     bech32(): string {
-        let words = bech32.toWords(this.pubkey());
-        let address = bech32.encode(HRP, words);
+        const words = bech32.toWords(this.pubkey());
+        const address = bech32.encode(this.hrp, words);
         return address;
     }
 
@@ -54,6 +56,13 @@ export class UserAddress {
      */
     pubkey(): Buffer {
         return this.buffer;
+    }
+
+    /**
+     * Returns the human-readable-part of the bech32 addresses.
+     */
+    getHrp(): string {
+        return this.hrp;
     }
 
     /**

--- a/src/userAddress.ts
+++ b/src/userAddress.ts
@@ -1,10 +1,6 @@
 import * as bech32 from "bech32";
+import { LibraryConfig } from "./config";
 import { ErrBadAddress } from "./errors";
-
-/**
- * The human-readable-part of the bech32 addresses.
- */
-const DEFAULT_HRP = "erd";
 
 /**
  * @internal
@@ -16,7 +12,7 @@ export class UserAddress {
 
     public constructor(buffer: Buffer, hrp?: string) {
         this.buffer = buffer;
-        this.hrp = hrp || DEFAULT_HRP;
+        this.hrp = hrp || LibraryConfig.DefaultAddressHrp;
     }
 
     static newFromBech32(value: string): UserAddress {
@@ -92,7 +88,7 @@ function decodeFromBech32(options: { value: string; allowCustomHrp: boolean }): 
     }
 
     // Workaround, in order to avoid behavioral breaking changes on legacy flows.
-    if (!allowCustomHrp && hrp != DEFAULT_HRP) {
+    if (!allowCustomHrp && hrp != LibraryConfig.DefaultAddressHrp) {
         throw new ErrBadAddress(value);
     }
 

--- a/src/userAddress.ts
+++ b/src/userAddress.ts
@@ -7,7 +7,8 @@ import { ErrBadAddress } from "./errors";
 const DEFAULT_HRP = "erd";
 
 /**
- * A user Address, as an immutable object.
+ * @internal
+ * For internal use only.
  */
 export class UserAddress {
     private readonly buffer: Buffer;
@@ -18,16 +19,14 @@ export class UserAddress {
         this.hrp = hrp || DEFAULT_HRP;
     }
 
-    /**
-     * Creates an address object from a bech32-encoded string
-     */
     static newFromBech32(value: string): UserAddress {
         const { hrp, pubkey } = decodeFromBech32({ value, allowCustomHrp: true });
         return new UserAddress(pubkey, hrp);
     }
 
     /**
-     * Use {@link newFromBech32} instead.
+     * @internal
+     * For internal use only.
      */
     static fromBech32(value: string): UserAddress {
         // On this legacy flow, we do not accept addresses with custom hrp (in order to avoid behavioral breaking changes).
@@ -57,14 +56,7 @@ export class UserAddress {
     pubkey(): Buffer {
         return this.buffer;
     }
-
-    /**
-     * Returns the human-readable-part of the bech32 addresses.
-     */
-    getHrp(): string {
-        return this.hrp;
-    }
-
+    
     /**
      * Returns the bech32 representation of the address
      */

--- a/src/userKeys.ts
+++ b/src/userKeys.ts
@@ -73,8 +73,8 @@ export class UserPublicKey {
         return this.buffer.toString("hex");
     }
 
-    toAddress(): UserAddress {
-        return new UserAddress(this.buffer);
+    toAddress(hrp?: string): UserAddress {
+        return new UserAddress(this.buffer, hrp);
     }
 
     valueOf(): Buffer {

--- a/src/userSigner.ts
+++ b/src/userSigner.ts
@@ -9,9 +9,8 @@ interface IUserSecretKey {
 }
 
 interface IUserPublicKey {
-    toAddress(): { bech32(): string; };
+    toAddress(hrp?: string): { bech32(): string; };
 }
-
 
 /**
  * ed25519 signer
@@ -45,8 +44,8 @@ export class UserSigner {
     /**
      * Gets the address of the signer.
      */
-    getAddress(): UserAddress {
-        const bech32 = this.secretKey.generatePublicKey().toAddress().bech32();
+    getAddress(hrp?: string): UserAddress {
+        const bech32 = this.secretKey.generatePublicKey().toAddress(hrp).bech32();
         return UserAddress.fromBech32(bech32);
     }
 }

--- a/src/userSigner.ts
+++ b/src/userSigner.ts
@@ -46,6 +46,6 @@ export class UserSigner {
      */
     getAddress(hrp?: string): UserAddress {
         const bech32 = this.secretKey.generatePublicKey().toAddress(hrp).bech32();
-        return UserAddress.fromBech32(bech32);
+        return UserAddress.newFromBech32(bech32);
     }
 }

--- a/src/userWallet.ts
+++ b/src/userWallet.ts
@@ -146,15 +146,15 @@ export class UserWallet {
     /**
      * Converts the encrypted keyfile to plain JavaScript object.
      */
-    toJSON(): any {
+    toJSON(addressHrp?: string): any {
         if (this.kind == UserWalletKind.SecretKey) {
-            return this.toJSONWhenKindIsSecretKey();
+            return this.toJSONWhenKindIsSecretKey(addressHrp);
         }
 
         return this.toJSONWhenKindIsMnemonic();
     }
 
-    private toJSONWhenKindIsSecretKey(): any {
+    private toJSONWhenKindIsSecretKey(addressHrp?: string): any {
         if (!this.publicKeyWhenKindIsSecretKey) {
             throw new Err("Public key isn't available");
         }
@@ -166,7 +166,7 @@ export class UserWallet {
             kind: this.kind,
             id: this.encryptedData.id,
             address: this.publicKeyWhenKindIsSecretKey.hex(),
-            bech32: this.publicKeyWhenKindIsSecretKey.toAddress().toString(),
+            bech32: this.publicKeyWhenKindIsSecretKey.toAddress(addressHrp).toString(),
             crypto: cryptoSection
         };
 

--- a/src/users.spec.ts
+++ b/src/users.spec.ts
@@ -40,6 +40,10 @@ describe("test user wallets", () => {
         assert.equal(mnemonic.deriveKey(0).generatePublicKey().toAddress().bech32(), "erd1l8g9dk3gz035gkjhwegsjkqzdu3augrwhcfxrnucnyyrpc2220pqg4g7na");
         assert.equal(mnemonic.deriveKey(1).generatePublicKey().toAddress().bech32(), "erd1fmhwg84rldg0xzngf53m0y607wvefvamh07n2mkypedx27lcqnts4zs09p");
         assert.equal(mnemonic.deriveKey(2).generatePublicKey().toAddress().bech32(), "erd1tyuyemt4xz2yjvc7rxxp8kyfmk2n3h8gv3aavzd9ru4v2vhrkcksptewtj");
+
+        assert.equal(mnemonic.deriveKey(0).generatePublicKey().toAddress("test").bech32(), "test1l8g9dk3gz035gkjhwegsjkqzdu3augrwhcfxrnucnyyrpc2220pqc6tnnf");
+        assert.equal(mnemonic.deriveKey(1).generatePublicKey().toAddress("xerd").bech32(), "xerd1fmhwg84rldg0xzngf53m0y607wvefvamh07n2mkypedx27lcqntsj4adj4");
+        assert.equal(mnemonic.deriveKey(2).generatePublicKey().toAddress("yerd").bech32(), "yerd1tyuyemt4xz2yjvc7rxxp8kyfmk2n3h8gv3aavzd9ru4v2vhrkcksn8p0n5");
     });
 
     it("should create secret key", () => {
@@ -346,6 +350,10 @@ describe("test user wallets", () => {
         assert.equal(UserSigner.fromWallet(keyFileObjectWithMnemonic, password, 0).getAddress().bech32(), "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
         assert.equal(UserSigner.fromWallet(keyFileObjectWithMnemonic, password, 1).getAddress().bech32(), "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx");
         assert.equal(UserSigner.fromWallet(keyFileObjectWithMnemonic, password, 2).getAddress().bech32(), "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8");
+
+        assert.equal(UserSigner.fromWallet(keyFileObjectWithMnemonic, password, 0).getAddress("test").bech32(), "test1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ss5hqhtr");
+        assert.equal(UserSigner.fromWallet(keyFileObjectWithMnemonic, password, 1).getAddress("xerd").bech32(), "xerd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruq9thc9j");
+        assert.equal(UserSigner.fromWallet(keyFileObjectWithMnemonic, password, 2).getAddress("yerd").bech32(), "yerd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaqgh23pp");
     });
 
     it("should throw error when decrypting secret key with keystore-mnemonic file", async function () {


### PR DESCRIPTION
 - Add support for custom HRP (non-breaking change).
 - `UserAddress` suffered some non-clean adjustments. However, it's an internal class. Additionally, it will be dropped once `sdk-wallet` is merged into `sdk-core` (in the future).